### PR TITLE
The ErrorPage is not used correctly when RELEASE mode.

### DIFF
--- a/ContosoUniversity.IntegrationTests/ContosoUniversity.IntegrationTests.csproj
+++ b/ContosoUniversity.IntegrationTests/ContosoUniversity.IntegrationTests.csproj
@@ -27,4 +27,8 @@
     <ProjectReference Include="..\ContosoUniversity\ContosoUniversity.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>

--- a/ContosoUniversity/Pages/Error.cshtml
+++ b/ContosoUniversity/Pages/Error.cshtml
@@ -1,6 +1,5 @@
 ﻿@page
-@model ErrorViewModel
-@{
+@model ErrorPage
     ViewData["Title"] = "Error";
 }
 

--- a/ContosoUniversity/Pages/Error.cshtml.cs
+++ b/ContosoUniversity/Pages/Error.cshtml.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Diagnostics;
+
+namespace ContosoUniversity.Pages
+{
+    public class ErrorPage : PageModel
+    {
+        public string RequestId { get; set; }
+
+        public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+
+        [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+        public void OnGet()
+        {
+            RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
+        }
+    }
+}

--- a/ContosoUniversity/Startup.cs
+++ b/ContosoUniversity/Startup.cs
@@ -53,7 +53,7 @@ namespace ContosoUniversity
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             app.UseMiniProfiler();
-
+            
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
@@ -62,17 +62,11 @@ namespace ContosoUniversity
             }
             else
             {
-                app.UseExceptionHandler("/Home/Error");
+                app.UseExceptionHandler("/Error");
             }
 
             app.UseStaticFiles();
-
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
+            app.UseMvc();
         }
     }
 }


### PR DESCRIPTION
Probably a left-over from the migration from plain old MVC towards razor pages.
app.UseMvc still did a setup of controller route which is redundant I believe.

- add ErrorPage model
- point to the correct error page
- no need for controller route setup since we are using pages