### PR TITLE
Fix to workaround EFCore issue #12280

### DIFF
--- a/ContosoUniversity/Pages/Instructors/CreateEdit.cshtml.cs
+++ b/ContosoUniversity/Pages/Instructors/CreateEdit.cshtml.cs
@@ -157,7 +157,7 @@ namespace ContosoUniversity.Pages.Instructors
                 {
                     CourseID = course.Id,
                     Title = course.Title,
-                    Assigned = instructorCourses.Contains(course.Id)
+                    Assigned = instructorCourses.Any() && instructorCourses.Contains(course.Id)
                 }).ToList();
                 model.AssignedCourses = viewModel;
             }


### PR DESCRIPTION
This is a quick fix to workaround EF Core [#12280](https://github.com/aspnet/EntityFrameworkCore/issues/12280) which occurs only when an enumerable is empty, such as when attempting to create a new instructor. This is due to be fixed in v2.1.3 of EF Core.