### PR TITLE
Make it possible to save a department from the edit page

### DIFF
--- a/ContosoUniversity/Infrastructure/Tags/TagConventions.cs
+++ b/ContosoUniversity/Infrastructure/Tags/TagConventions.cs
@@ -19,8 +19,8 @@ namespace ContosoUniversity.Infrastructure.Tags
                 .AddClass("datepicker")
                 .Value(m.Value<DateTime?>() != null ? m.Value<DateTime>().ToShortDateString() : string.Empty));
             Editors.If(er => er.Accessor.Name.EndsWith("id", StringComparison.OrdinalIgnoreCase)).BuildBy(a => new HiddenTag().Value(a.StringValue()));
-            Editors.IfPropertyIs<byte[]>().BuildBy(a => new HiddenTag().Value(Convert.ToBase64String(a.Value<byte[]>())));
-
+            Editors.IfPropertyIs<byte[]>().ModifyWith(m => m.CurrentTag.Value(Convert.ToBase64String(m.Value<byte[]>())));
+            Editors.IfPropertyIs<byte[]>().BuildBy(a => new HiddenTag());
 
             Labels.Always.AddClass("control-label");
             Labels.ModifyForAttribute<DisplayAttribute>((t, a) => t.Text(a.Name));


### PR DESCRIPTION
Saving a department was previously impossible due to how `byte[]` arrays were handled, see attached screenshot. Make it so that the value of `byte[]` is used instead of the `ToString()` representation of the `byte[]`.

Not sure if this is the best fix for the problem, or if one should modify how `BuildBy(...)` in HtmlTags works instead ...

![image](https://user-images.githubusercontent.com/2734983/43364396-9fa3326c-9319-11e8-9d55-b68aee2447e7.png)


 