### PR TITLE
fix(#28): "rh" executable fix

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -31,9 +31,9 @@ $suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch
 $commitHash = $(git rev-parse --short HEAD)
 $buildSuffix = @{ $true = "$($suffix)-$($commitHash)"; $false = "$($branch)-$($commitHash)" }[$suffix -ne ""]
 
-exec { & rh /d=ContosoUniversityDotNetCore-Pages /f=ContosoUniversity\App_Data /s="(LocalDb)\mssqllocaldb" /silent }
-exec { & rh /d=ContosoUniversityDotNetCore-Pages-Test /f=ContosoUniversity\App_Data /s="(LocalDb)\mssqllocaldb" /silent /drop }
-exec { & rh /d=ContosoUniversityDotNetCore-Pages-Test /f=ContosoUniversity\App_Data /s="(LocalDb)\mssqllocaldb" /silent /simple }
+exec { & .\tools\rh /d=ContosoUniversityDotNetCore-Pages /f=ContosoUniversity\App_Data /s="(LocalDb)\mssqllocaldb" /silent }
+exec { & .\tools\rh /d=ContosoUniversityDotNetCore-Pages-Test /f=ContosoUniversity\App_Data /s="(LocalDb)\mssqllocaldb" /silent /drop }
+exec { & .\tools\rh /d=ContosoUniversityDotNetCore-Pages-Test /f=ContosoUniversity\App_Data /s="(LocalDb)\mssqllocaldb" /silent /simple }
 
 exec { & dotnet restore }
 


### PR DESCRIPTION
fix(#28): "rh" executable lives in the "tools" subfolder.