### PR TITLE
Rename variables and classes to follow the convention

### DIFF
--- a/ContosoUniversity/Pages/About.cshtml.cs
+++ b/ContosoUniversity/Pages/About.cshtml.cs
@@ -10,18 +10,18 @@ namespace ContosoUniversity.Pages;
 
 public class AboutPage : PageModel
 {
-    private readonly SchoolContext _context;
+    private readonly SchoolContext _db;
 
-    public AboutPage(SchoolContext context)
+    public AboutPage(SchoolContext db)
     {
-        _context = context;
+        _db = db;
     }
 
     public IEnumerable<EnrollmentDateGroup> Data { get; private set; }
 
     public async Task OnGetAsync()
     {
-        var groups = await _context
+        var groups = await _db
             .Students
             .GroupBy(x => x.EnrollmentDate)
             .Select(x => new EnrollmentDateGroup

--- a/ContosoUniversity/Pages/Courses/Create.cshtml.cs
+++ b/ContosoUniversity/Pages/Courses/Create.cshtml.cs
@@ -32,11 +32,11 @@ public class Create : PageModel
         public Department Department { get; init; }
     }
 
-    public class Handler : IRequestHandler<Command, int>
+    public class CommandHandler : IRequestHandler<Command, int>
     {
         private readonly SchoolContext _db;
 
-        public Handler(SchoolContext db) => _db = db;
+        public CommandHandler(SchoolContext db) => _db = db;
 
         public async Task<int> Handle(Command message, CancellationToken token)
         {

--- a/ContosoUniversity/Pages/Courses/Details.cshtml.cs
+++ b/ContosoUniversity/Pages/Courses/Details.cshtml.cs
@@ -50,12 +50,12 @@ public class Details : PageModel
         public MappingProfile() => CreateProjection<Course, Model>();
     }
 
-    public class Handler : IRequestHandler<Query, Model>
+    public class QueryHandler : IRequestHandler<Query, Model>
     {
         private readonly SchoolContext _db;
         private readonly IConfigurationProvider _configuration;
 
-        public Handler(SchoolContext db, IConfigurationProvider configuration)
+        public QueryHandler(SchoolContext db, IConfigurationProvider configuration)
         {
             _db = db;
             _configuration = configuration;

--- a/ContosoUniversity/Pages/Courses/Index.cshtml.cs
+++ b/ContosoUniversity/Pages/Courses/Index.cshtml.cs
@@ -42,12 +42,12 @@ public class Index : PageModel
         public MappingProfile() => CreateProjection<Course, Result.Course>();
     }
 
-    public class Handler : IRequestHandler<Query, Result>
+    public class QueryHandler : IRequestHandler<Query, Result>
     {
         private readonly SchoolContext _db;
         private readonly IConfigurationProvider _configuration;
 
-        public Handler(SchoolContext db, IConfigurationProvider configuration)
+        public QueryHandler(SchoolContext db, IConfigurationProvider configuration)
         {
             _db = db;
             _configuration = configuration;

--- a/ContosoUniversity/Pages/Departments/Create.cshtml.cs
+++ b/ContosoUniversity/Pages/Departments/Create.cshtml.cs
@@ -57,9 +57,9 @@ public class Create : PageModel
 
     public class CommandHandler : IRequestHandler<Command, int>
     {
-        private readonly SchoolContext _context;
+        private readonly SchoolContext _db;
 
-        public CommandHandler(SchoolContext context) => _context = context;
+        public CommandHandler(SchoolContext db) => _db = db;
 
         public async Task<int> Handle(Command message, CancellationToken token)
         {
@@ -71,9 +71,9 @@ public class Create : PageModel
                 StartDate = message.StartDate!.Value
             };
 
-            await _context.Departments.AddAsync(department, token);
+            await _db.Departments.AddAsync(department, token);
 
-            await _context.SaveChangesAsync(token);
+            await _db.SaveChangesAsync(token);
 
             return department.Id;
         }

--- a/ContosoUniversity/Pages/Departments/Details.cshtml.cs
+++ b/ContosoUniversity/Pages/Departments/Details.cshtml.cs
@@ -51,18 +51,18 @@ public class Details : PageModel
         
     public class QueryHandler : IRequestHandler<Query, Model>
     {
-        private readonly SchoolContext _context;
+        private readonly SchoolContext _db;
         private readonly IConfigurationProvider _configuration;
 
-        public QueryHandler(SchoolContext context, IConfigurationProvider configuration)
+        public QueryHandler(SchoolContext db, IConfigurationProvider configuration)
         {
-            _context = context;
+            _db = db;
             _configuration = configuration;
         }
 
         public Task<Model> Handle(Query message, 
             CancellationToken token) => 
-            _context.Departments
+            _db.Departments
                 .Where(m => m.Id == message.Id)
                 .ProjectTo<Model>(_configuration)
                 .DecompileAsync()

--- a/ContosoUniversity/Pages/Departments/Index.cshtml.cs
+++ b/ContosoUniversity/Pages/Departments/Index.cshtml.cs
@@ -48,18 +48,18 @@ public class Index : PageModel
 
     public class QueryHandler : IRequestHandler<Query, List<Model>>
     {
-        private readonly SchoolContext _context;
+        private readonly SchoolContext _db;
         private readonly IConfigurationProvider _configuration;
 
-        public QueryHandler(SchoolContext context, 
+        public QueryHandler(SchoolContext db, 
             IConfigurationProvider configuration)
         {
-            _context = context;
+            _db = db;
             _configuration = configuration;
         }
 
         public Task<List<Model>> Handle(Query message, 
-            CancellationToken token) => _context
+            CancellationToken token) => _db
             .Departments
             .ProjectTo<Model>(_configuration)
             .DecompileAsync()

--- a/ContosoUniversity/Pages/Instructors/Details.cshtml.cs
+++ b/ContosoUniversity/Pages/Instructors/Details.cshtml.cs
@@ -57,12 +57,12 @@ public class Details : PageModel
         public MappingProfile() => CreateProjection<Instructor, Model>();
     }
 
-    public class Handler : IRequestHandler<Query, Model>
+    public class QueryHandler : IRequestHandler<Query, Model>
     {
         private readonly SchoolContext _db;
         private readonly IConfigurationProvider _configuration;
 
-        public Handler(SchoolContext db, IConfigurationProvider configuration)
+        public QueryHandler(SchoolContext db, IConfigurationProvider configuration)
         {
             _db = db;
             _configuration = configuration;

--- a/ContosoUniversity/Pages/Instructors/Index.cshtml.cs
+++ b/ContosoUniversity/Pages/Instructors/Index.cshtml.cs
@@ -139,12 +139,12 @@ public class Index : PageModel
         }
     }
 
-    public class Handler : IRequestHandler<Query, Model>
+    public class QueryHandler : IRequestHandler<Query, Model>
     {
         private readonly SchoolContext _db;
         private readonly IConfigurationProvider _configuration;
 
-        public Handler(SchoolContext db, IConfigurationProvider configuration)
+        public QueryHandler(SchoolContext db, IConfigurationProvider configuration)
         {
             _db = db;
             _configuration = configuration;

--- a/ContosoUniversity/Pages/Students/Create.cshtml.cs
+++ b/ContosoUniversity/Pages/Students/Create.cshtml.cs
@@ -49,11 +49,11 @@ public class Create : PageModel
         }
     }
 
-    public class Handler : IRequestHandler<Command, int>
+    public class CommandHandler : IRequestHandler<Command, int>
     {
         private readonly SchoolContext _db;
 
-        public Handler(SchoolContext db) => _db = db;
+        public CommandHandler(SchoolContext db) => _db = db;
 
         public async Task<int> Handle(Command message, CancellationToken token)
         {

--- a/ContosoUniversity/Pages/Students/Details.cshtml.cs
+++ b/ContosoUniversity/Pages/Students/Details.cshtml.cs
@@ -55,12 +55,12 @@ public class Details : PageModel
         }
     }
 
-    public class Handler : IRequestHandler<Query, Model>
+    public class QueryHandler : IRequestHandler<Query, Model>
     {
         private readonly SchoolContext _db;
         private readonly IConfigurationProvider _configuration;
 
-        public Handler(SchoolContext db, IConfigurationProvider configuration)
+        public QueryHandler(SchoolContext db, IConfigurationProvider configuration)
         {
             _db = db;
             _configuration = configuration;


### PR DESCRIPTION
- The majority of `SchoolContext` variables are called `db`
- The majority of `Handler` classes are prefixed with `Command` or `Query`